### PR TITLE
Add setting to control the default branch value (and change to the defaults `main`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ Then set the following settings:
 `WAGTAILLOCALIZE_GIT_URL` - This is a URL to an empty git repository that `wagtail-localize-git` will push source strings to and fetch translations from.
 `WAGTAILLOCALIZE_GIT_CLONE_DIR` - The local directory where the git repository will be checked out.
 
+By default, `wagtail-localize-git` will try to checkout and work with the `main` branch. To change that, set `WAGTAILLOCALIZE_GIT_DEFAULT_BRANCH`
+to your repository's default branch (e.g. `master`)
+
 ## Synchronisation
 
 Once this is configured, you can use the `sync_git` management command to push/pull changes. This management command should be set up in your server's crontab to run often (preferably, every 10 minutes).

--- a/wagtail_localize_git/tests/test_git.py
+++ b/wagtail_localize_git/tests/test_git.py
@@ -9,7 +9,12 @@ import toml
 from django.test import TestCase, override_settings
 from wagtail.core.models import Locale
 
-from wagtail_localize_git.git import Repository, RepositoryReader, RepositoryWriter
+from wagtail_localize_git.git import (
+    DEFAULT_BRANCH,
+    Repository,
+    RepositoryReader,
+    RepositoryWriter,
+)
 
 from .utils import GitRepositoryUtils
 
@@ -20,7 +25,7 @@ class GitTestCase(GitRepositoryUtils, TestCase):
         self.repo_dir, self.repo = self.make_repo()
         self.repo_dir = tempfile.TemporaryDirectory()
         self.initial_commit = self.repo.gitpython.index.commit("initial commit")
-        self.repo.gitpython.create_head("master")
+        self.repo.gitpython.create_head(DEFAULT_BRANCH)
 
 
 class TestRepository(GitTestCase):
@@ -94,7 +99,7 @@ class TestRepositoryClonePullPush(GitTestCase):
             "+refs/heads/*:refs/remotes/origin/*"
         )
         self.repo.pygit.lookup_reference.assert_called_with(
-            "refs/remotes/origin/master"
+            f"refs/remotes/origin/{DEFAULT_BRANCH}"
         )
         self.repo.pygit.head.set_target.assert_called_with("1234")
         self.assertFalse(self.repo.repo_is_empty)
@@ -110,7 +115,7 @@ class TestRepositoryClonePullPush(GitTestCase):
             "+refs/heads/*:refs/remotes/origin/*"
         )
         self.repo.pygit.lookup_reference.assert_called_with(
-            "refs/remotes/origin/master"
+            f"refs/remotes/origin/{DEFAULT_BRANCH}"
         )
         self.repo.pygit.head.set_target.assert_not_called()
         self.assertTrue(self.repo.repo_is_empty)
@@ -120,7 +125,7 @@ class TestRepositoryClonePullPush(GitTestCase):
         self.repo.push()
 
         self.repo.gitpython.remotes.origin.push.assert_called_with(
-            ["refs/heads/master"]
+            [f"refs/heads/{DEFAULT_BRANCH}"]
         )
 
 

--- a/wagtail_localize_git/tests/test_sync.py
+++ b/wagtail_localize_git/tests/test_sync.py
@@ -51,7 +51,7 @@ class TestPull(GitRepositoryUtils, TestCase):
     def make_test_repo(self):
         repo_dir, repo = self.make_repo()
         repo.gitpython.index.commit("Initial commit")
-        repo.gitpython.create_head("master")
+        repo.gitpython.create_head("main")
         return repo
 
     def commit_translation(
@@ -301,7 +301,7 @@ class TestSyncManager(GitRepositoryUtils, TestCase):
 
         self.remote_repo_dir, self.remote_repo = self.make_repo()
         self.remote_repo.gitpython.index.commit("Initial commit")
-        self.remote_repo.gitpython.create_head("master")
+        self.remote_repo.gitpython.create_head("main")
         self.local_repo_dir, self.local_repo = self.clone_repo(self.remote_repo_dir)
 
         self.settings = {

--- a/wagtail_localize_git/tests/utils.py
+++ b/wagtail_localize_git/tests/utils.py
@@ -7,7 +7,7 @@ import pygit2
 from django.test import override_settings
 from git import Repo
 
-from wagtail_localize_git.git import Repository
+from wagtail_localize_git.git import DEFAULT_BRANCH, Repository
 
 
 class GitRepositoryUtils:
@@ -26,7 +26,7 @@ class GitRepositoryUtils:
         repo_dir = tempfile.TemporaryDirectory()
         self.dirs_to_cleanup.append(repo_dir)
 
-        gitpython = Repo.init(repo_dir.name, bare=True)
+        gitpython = Repo.init(repo_dir.name, bare=True, initial_branch=DEFAULT_BRANCH)
         pygit = pygit2.Repository(repo_dir.name)
 
         return repo_dir.name, Repository(pygit, gitpython)
@@ -58,7 +58,12 @@ class GitRepositoryUtils:
         )
 
         repo.pygit.create_commit(
-            "refs/heads/master", sig, sig, message, tree, [repo.pygit.head.target]
+            f"refs/heads/{DEFAULT_BRANCH}",
+            sig,
+            sig,
+            message,
+            tree,
+            [repo.pygit.head.target],
         )
 
         return repo.pygit.head.target.hex


### PR DESCRIPTION
This PR fixes #13 by introducing a new `WAGTAILLOCALIZE_GIT_DEFAULT_BRANCH` settings that defaults to `main`

I've investigated various alternative, but there's no reliable way to do this out of the box that I could find