### PR TITLE
Add sync retry mechanism

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This is useful for when you are using external translation tools for translating
 
 ## Installation
 
-This plugin requires Wagtail 2.11 with [internationalisation enabled](https://docs.wagtail.io/en/v2.11/advanced_topics/i18n.html#configuration) and [Wagtail Localize](https://github.com/wagtail/wagtail-localize).
+This plugin requires Wagtail >= 2.11 with [internationalisation enabled](https://docs.wagtail.org/en/stable/advanced_topics/i18n.html#configuration) and [Wagtail Localize](https://github.com/wagtail/wagtail-localize).
 
 Install both `wagtail-localize` and `wagtail-localize-git`, then add the following to your `INSTALLED_APPS`:
 

--- a/wagtail_localize_git/git.py
+++ b/wagtail_localize_git/git.py
@@ -48,22 +48,17 @@ class Repository:
         # GitPython push() returns a list of PushInfo instance for each head used in
         # the push. The PushInfo instance will have any errors added to flags.
         # In case of total failure, the returned list is empty.
+        # See https://github.com/gitpython-developers/GitPython/blob/b3f873a/git/remote.py#L180-L218
         refs = self.gitpython.remotes.origin.push([f"refs/heads/{DEFAULT_BRANCH}"])
         if not refs:
             return False
         push_info = refs[0]
-        if any(
+        return not any(
             [
                 push_info.flags & push_info.ERROR,
                 push_info.flags & push_info.DELETED,
-                push_info.flags & push_info.REJECTED,
-                push_info.flags & push_info.REMOTE_FAILURE,
-                push_info.flags & push_info.REMOTE_REJECTED,
             ]
-        ):
-            return False
-
-        return True
+        )
 
     def get_changed_files(self, old_commit, new_commit):
         """


### PR DESCRIPTION
This PR adds a simple retry mechanism to fix #19.

Use case:
1. sync pulls data from remote.
2. the remote is immediately updated (different head commit SHA)
3. sync tries to push and fails as it gets rejected.

By pulling again we should be in a position to push again.

This is by no means a comprehensive in that it is possible to reach a state whereby when pulling on retry fails due to a need to merge. This will raise an exception and would require manual intervention.